### PR TITLE
Add .gitignore for Python project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,91 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# IDE settings
+.idea/
+.vscode/
+*.swp
+*.swo
+*~
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Benchmark outputs (generated at runtime)
+metrics/
+data/
+
+# OS generated files
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db


### PR DESCRIPTION
## Summary

This PR adds a comprehensive `.gitignore` file to the repository.

## Changes

The `.gitignore` file includes patterns for:

- **Python artifacts**: bytecode (`__pycache__/`, `*.pyc`), distribution packages, egg files
- **Virtual environments**: `.venv/`, `venv/`, `env/`
- **IDE configurations**: `.idea/`, `.vscode/`, editor swap files
- **Test/coverage outputs**: `.pytest_cache/`, `.coverage`, `htmlcov/`
- **Benchmark outputs**: `metrics/`, `data/` directories (generated at runtime)
- **OS-specific files**: `.DS_Store`, `Thumbs.db`

## Motivation

Currently the repository lacks a `.gitignore` file, which can lead to:
- Accidental commits of Python bytecode and cache files
- Local IDE configurations polluting the repository
- Generated benchmark outputs being tracked unnecessarily

This change helps maintain a clean repository and prevents contributors from accidentally committing local or generated files.

## Testing

No code changes - this only adds ignore patterns for common files that should not be tracked.